### PR TITLE
Compile with -std=gnu99 flag for old versions of GCC

### DIFF
--- a/attacker/variant1_linux/Makefile
+++ b/attacker/variant1_linux/Makefile
@@ -1,5 +1,5 @@
 all: main.c
-	gcc main.c -Os -Wall -o leak
+	gcc main.c -Os -Wall -o leak -std=gnu99
 
 clean:
 	@rm -rf leak


### PR DESCRIPTION
Attempted to build with GCC version 4.8.4 and it threw a bunch of erorrs:

```
main.c:21:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
```

Adding the `-std=gnu99` and compiled successfully with GCC 4.8.4 and 9.1.0.